### PR TITLE
Backported changes from #3 to pod to make usage more realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Nanoid - Perl implementation of [Nano ID](https://github.com/ai/nanoid)
 
     use Nanoid;
 
-    my $default = Nanoid::generate();                    # length 21 / use URL-friendly characters
-    my $custom1 = Nanoid::generate(10);                  # length 10 / use URL-friendly characters
-    my $custom2 = Nanoid::generate(10, 'abcdef012345');  # length 10 / use 'abcdef012345' characters
+    my $default = Nanoid::generate();                                        # length 21 / use URL-friendly characters
+    my $custom1 = Nanoid::generate(size => 10);                              # length 10 / use URL-friendly characters
+    my $custom2 = Nanoid::generate(size => 10, alphabet => 'abcdef012345');  # length 10 / use 'abcdef012345' characters
 
 # DESCRIPTION
 

--- a/lib/Nanoid.pm
+++ b/lib/Nanoid.pm
@@ -65,15 +65,15 @@ __END__
 
 =head1 NAME
 
-Nanoid - Perl implementation of L<nanoid|https://github.com/ai/nanoid>
+Nanoid - Perl implementation of L<Nano ID|https://github.com/ai/nanoid>
 
 =head1 SYNOPSIS
 
     use Nanoid;
 
-    my $default = Nanoid::generate();                    # length 21 / use URL-friendry character
-    my $custom1 = Nanoid::generate(10);                  # length 10 / use URL-friendry character
-    my $custom2 = Nanoid::generate(10, 'abcdef012345');  # length 10 / use 'abcdef012345'
+    my $default = Nanoid::generate();                                        # length 21 / use URL-friendly characters
+    my $custom1 = Nanoid::generate(size => 10);                              # length 10 / use URL-friendly characters
+    my $custom2 = Nanoid::generate(size => 10, alphabet => 'abcdef012345');  # length 10 / use 'abcdef012345' characters
 
 
 =head1 DESCRIPTION


### PR DESCRIPTION
The usage was as follows, but the argument actually had to be passed in Hash.

now
```perl
Nanoid::generate(10, 'abcdef012345');
```

actual
```perl
Nanoid::generate(size => 10, alphabet => 'abcdef012345');
```

meta::cpan is rendering by POD usage.
Fixed POD so that meta::cpan can also see the latest README