### PR TITLE
fix Use of uninitialized value in bitwise

### DIFF
--- a/lib/Nanoid.pm
+++ b/lib/Nanoid.pm
@@ -44,14 +44,16 @@ sub generate {
         for my $idx ( 0 .. $step ) {
             my $byte;
 
-            $byte = $bytes->[$idx] & $mask;
+            if ( defined $bytes->[$idx] ) {
+                $byte = $bytes->[$idx] & $mask;
 
-            if ( defined $alphabet_array[$byte] ) {
-                $id .= $alphabet_array[$byte];
-
-                if ( length $id == $size ) {
-                    return $id;
+                if ( defined $alphabet_array[$byte] ) {
+                    $id .= $alphabet_array[$byte];
                 }
+            }
+
+            if ( length $id == $size ) {
+                return $id;
             }
         }
     }


### PR DESCRIPTION
In very rare cases, the following error occurs

```
Unexpected warning: Use of uninitialized value in bitwise and (&) at Nanoid.pm line 47.
```

Perhaps $mask has a value, but $bytes->[$idx] may return undef.
Also, if you look closely, the JavaScript implementation adds an empty character in this case, and the behavior was slightly different.

In this PR, we have rewritten the logic to be as identical as possible to the original JavaScript implementation.
<https://github.com/ai/nanoid/blob/9b748729f8ad5409503b508b65958636e55bd87a/index.js#L60-L62>